### PR TITLE
allow cluster rg name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ vault/azure.yml
 vault/ssh-key.pub
 vault/ssh-key
 .vscode/
+
+.history
+*/**/.history
+

--- a/roles/ocp4-cloud-ipi/tasks/install.yml
+++ b/roles/ocp4-cloud-ipi/tasks/install.yml
@@ -4,6 +4,8 @@
   shell:
     cmd: "{{ user_path }}/openshift-install create cluster --dir {{ user_path }} --log-level debug"
     creates: "{{ user_path }}/auth"
+  environment:
+    ARM_SKIP_PROVIDER_REGISTRATION: "{{ skip_provider | default(false) | bool | lower }}"
 
 - name: '[INSTALL_CONFIG] Check pid of openshift-install'
   pids:

--- a/roles/ocp4-cloud-ipi/templates/install-config-private.yaml.j2
+++ b/roles/ocp4-cloud-ipi/templates/install-config-private.yaml.j2
@@ -42,6 +42,9 @@ platform:
     region: {{ azure_location }}
     baseDomainResourceGroupName: {{ azure_resource_group }}
     networkResourceGroupName: {{ azure_resource_group }}
+{% if azure_cluster_resource_group is defined %}
+    resourceGroupName: {{ azure_cluster_resource_group }}
+{% endif %}
     virtualNetwork: {{ azure_vnet_name }}
     controlPlaneSubnet: control-plane
     computeSubnet: compute

--- a/vars/vars-private-rhel.yml
+++ b/vars/vars-private-rhel.yml
@@ -4,7 +4,10 @@ cluster_name: 'ocp4'
 
 # Azure parameters
 #azure_resource_group: adecorte-rhel-rg
+#azure_cluster_resource_group: adecorte-cluster-rhel-rg
 #azure_location: westeurope
+
+skip_provider: true
 
 egress: "LoadBalancer"
 azure_outboundtype: "Loadbalancer"


### PR DESCRIPTION
* allow us to specify name of the rg for the cluster. Normally this is generated, but in this environment, it will be pre-generated and provided to us
* also, we want to disable provider resource checking and automatic registration, as the environment we are deploying into, only required providers are registered manually, as a security measure