### PR TITLE
Skip all the openshift-install commands if auth is already there

### DIFF
--- a/roles/ocp4-cloud-ipi/tasks/install.yml
+++ b/roles/ocp4-cloud-ipi/tasks/install.yml
@@ -21,10 +21,12 @@
 - name: '[INSTALL_CONFIG] Wait for the Bootstrap'
   shell:
     cmd: "{{ user_path }}/openshift-install wait-for bootstrap-complete --dir {{ user_path }}"
+    creates: "{{ user_path }}/auth"
 
 - name: '[INSTALL_CONFIG] Wait for the cluster'
   shell:
     cmd: "{{ user_path }}/openshift-install wait-for install-complete --dir {{ user_path }}"
+    creates: "{{ user_path }}/auth"
 
 - name: '[INSTALL_CONFIG] Create the kube filesystem'
   file:


### PR DESCRIPTION
As the openshift-install by design is not meant to be run after
the end of the install, so we just skip all the relevant steps

Fixes [AAP-4663](https://issues.redhat.com/browse/AAP-4663)